### PR TITLE
Fix start index in fourth step

### DIFF
--- a/PHDiff/PHDiff/Sources/DiffContext.swift
+++ b/PHDiff/PHDiff/Sources/DiffContext.swift
@@ -67,7 +67,7 @@ public final class DiffContext<T: Diffable> {
         }
 
         // Forth pass
-        var i = 1
+        var i = 0
         while(i < NA.count-1) {
             if let j = NA[i].index, j+1 < OA.count {
                 if NA[i+1].symbol != nil && NA[i+1].symbol === OA[j+1].symbol {

--- a/PHDiff/PHDiffTests/PHDiffTests.swift
+++ b/PHDiff/PHDiffTests/PHDiffTests.swift
@@ -60,6 +60,11 @@ final class PHDiffTests: XCTestCase {
         newArray = ["e", "b", "c", "d", "a"]
         steps = PHDiff.sortedSteps(fromArray: oldArray, toArray: newArray)
         XCTAssertTrue(oldArray.apply(steps: steps) == newArray)
+
+        oldArray = ["a", "b", "c"]
+        newArray = ["b", "c", "c"]
+        steps = PHDiff.sortedSteps(fromArray: oldArray, toArray: newArray)
+        XCTAssertEqual(steps, [ DiffStep.delete(value: "a", index: 0), DiffStep.insert(value: "c", index: 2) ])
     }
 
     func testDiffUpdate() {


### PR DESCRIPTION
Hi!
For example:
```
PHDiff.steps(fromArray: [1, 2, 3, 4], toArray: [2, 3, 4, 3, 4])
```
outputs:
```
[Delete 1 at index: 0, Delete 3 at index: 2, Delete 4 at index: 3, Insert 3 at index: 1, Insert 4 at index: 2, Insert 3 at index: 3, Insert 4 at index: 4]
```
instead
```
[Delete 1 at index: 0, Insert 3 at index: 3, Insert 4 at index: 4]
```