### PR TITLE
Reduce number of steps when moving items

### DIFF
--- a/PHDiff/PHDiff/Sources/PHDiff.swift
+++ b/PHDiff/PHDiff/Sources/PHDiff.swift
@@ -34,7 +34,7 @@ public struct PHDiff {
             deleteOffsets[j] = runningOffset
             if ref.symbol != nil {
                 steps.append(.delete(value: context.fromArray[j], index: j))
-                runningOffset += 1
+                runningOffset -= 1
             }
         }
 
@@ -49,9 +49,12 @@ public struct PHDiff {
                 }
 
                 // Checks for the current offset, if matches means that this move is not needed
-                let deleteOffset = deleteOffsets[j]
-                if (j - deleteOffset + runningOffset) != i {
+                let expectedOldIndex = j + runningOffset + deleteOffsets[j]
+                if expectedOldIndex != i {
                     steps.append(.move(value: context.toArray[i], fromIndex: j, toIndex: i))
+                    if expectedOldIndex > i {
+                        runningOffset += 1
+                    }
                 }
             } else {
                 steps.append(.insert(value: context.toArray[i], index: i))

--- a/PHDiff/PHDiffTests/PHDiffTests.swift
+++ b/PHDiff/PHDiffTests/PHDiffTests.swift
@@ -65,6 +65,19 @@ final class PHDiffTests: XCTestCase {
         newArray = ["b", "c", "c"]
         steps = PHDiff.sortedSteps(fromArray: oldArray, toArray: newArray)
         XCTAssertEqual(steps, [ DiffStep.delete(value: "a", index: 0), DiffStep.insert(value: "c", index: 2) ])
+
+        oldArray = ["a", "b", "c"]
+        newArray = ["c", "a", "b"]
+        steps = PHDiff.steps(fromArray: oldArray, toArray: newArray)
+        XCTAssertEqual(steps, [ DiffStep.move(value: "c", fromIndex: 2, toIndex: 0)])
+
+        oldArray = ["a", "b", "c"]
+        newArray = ["b", "c", "a"]
+        steps = PHDiff.steps(fromArray: oldArray, toArray: newArray)
+        XCTAssertEqual(steps, [
+            DiffStep.move(value: "b", fromIndex: 1, toIndex: 0),
+            DiffStep.move(value: "c", fromIndex: 2, toIndex: 1),
+        ])
     }
 
     func testDiffUpdate() {


### PR DESCRIPTION
Add increase in the value of `runningOffset` when item moved from unvisited parts (treat as the addition element)

Case:
```
["a", "b", "c", "d"] -> ["c", "d", "a", "b"]
```
now (move all items):
```
[Move c from index: 2 to index: 0, Move d from index: 3 to index: 1, Move a from index: 0 to index: 2, Move b from index: 1 to index: 3]
```
after change:
```
[Move c from index: 2 to index: 0, Move d from index: 3 to index: 1]
```